### PR TITLE
feat: Add feature to store switch operational data

### DIFF
--- a/src/repository_service/base_repository_service.py
+++ b/src/repository_service/base_repository_service.py
@@ -2,7 +2,7 @@ import logging
 
 import inject
 from sqlalchemy import create_engine, MetaData
-from sqlalchemy.orm import sessionmaker, registry, relationship
+from sqlalchemy.orm import sessionmaker, registry
 
 from src.configuration.base_configuration import BaseConfiguration
 from src.electricity_price_service.models.electricity_price_model import ElectricityPriceModel
@@ -12,6 +12,7 @@ from src.user_service.models.user_model import UserModel
 from src.weather_service.models.weather_model import WeatherModel
 from src.place_service.models.place_model import PlaceModel
 from src.location_service.models.location_model import LocationModel
+from src.switch_service.models.switch_data_model import SwitchDataModel
 
 
 class BaseRepositoryService:
@@ -42,4 +43,5 @@ class BaseRepositoryService:
         self.mapper_registry.map_imperatively(LocationModel, self.tables['location'])
         self.mapper_registry.map_imperatively(UserModel, self.tables['user'])
         self.mapper_registry.map_imperatively(PlaceModel, self.tables['place'])
+        self.mapper_registry.map_imperatively(SwitchDataModel, self.tables['switch_data'])
         self.metadata.create_all(self.engine)

--- a/src/repository_service/switch_repository_service.py
+++ b/src/repository_service/switch_repository_service.py
@@ -1,6 +1,7 @@
 from sqlalchemy.exc import IntegrityError
 from src.repository_service.base_repository_service import BaseRepositoryService
 from src.switch_service.models.switch_model import SwitchModel
+from src.switch_service.models.switch_data_model import SwitchDataModel
 from src.place_service.models.place_model import PlaceModel
 
 
@@ -79,7 +80,7 @@ class SwitchRepositoryService(BaseRepositoryService):
 
         Args:
             uuid (str): The uuid of the switch to be retrieved.
-            user_id (str): The user id of the user who owns the switch.
+            user_id (int): The user id of the user who owns the switch.
 
         Returns:
             SwitchModel: SwitchModel object retrieved from the database. ValueError is raised if the switch does not exist.
@@ -115,3 +116,23 @@ class SwitchRepositoryService(BaseRepositoryService):
         except Exception as e:
             self.logger.error(f"Error deleting switch data from database. Error = {e}")
             raise e
+
+    def store_switch_operational_data(self, switch_data):
+        """
+        Stores a switch operational data object into the database.
+
+        Args: switch_data (SwitchDataModel): SwitchDataModel object to be stored in the database.
+
+        Returns:
+            None, raises an IntegrityError if the switch data already exists in the database.
+        """
+        try:
+            with self.session_maker() as session:
+                session.add(switch_data)
+                session.commit()
+        except IntegrityError:
+            self.logger.error(f"Switch data with timestamp {switch_data.timestamp} already exists in the database.")
+            raise
+        except Exception as e:
+            self.logger.error(f"Error storing switch data into database. Error = {e}")
+            raise

--- a/src/repository_service/tables/registry.py
+++ b/src/repository_service/tables/registry.py
@@ -4,6 +4,7 @@ from src.repository_service.tables.switch_table import create_switch_table
 from src.repository_service.tables.user_table import create_user_table
 from src.repository_service.tables.place_table import create_place_table
 from src.repository_service.tables.location_table import create_location_table
+from src.repository_service.tables.switch_data_table import create_switch_data_table
 
 
 def initialize_tables(metadata):
@@ -20,6 +21,7 @@ def initialize_tables(metadata):
         'weather': create_weather_table(metadata),
         'electricity_price': create_electricity_price_table(metadata),
         'switch': create_switch_table(metadata),
+        'switch_data': create_switch_data_table(metadata),
         'user': create_user_table(metadata),
         'place': create_place_table(metadata),
         'location': create_location_table(metadata)

--- a/src/repository_service/tables/switch_data_table.py
+++ b/src/repository_service/tables/switch_data_table.py
@@ -1,0 +1,20 @@
+from sqlalchemy import Table, Column, String, DateTime, Integer, Float, UniqueConstraint, ForeignKey, Enum
+from src.switch_service.models.switch_data_model import SwitchDataType
+
+def create_switch_data_table(metadata):
+    """
+    Create a table for switch data
+
+    Arguments:
+        metadata: SQLAlchemy MetaData object
+    """
+    return Table(
+        'switch_data', metadata,
+        Column('id', Integer, primary_key=True),
+        Column('switch_id', Integer, ForeignKey('switch.id'), nullable=False),
+        Column('data_type', Enum(SwitchDataType), nullable=False),
+        Column('log_cre_date', DateTime, nullable=False),
+        Column('value_text', String(50)),
+        Column('value_number', Float),
+        UniqueConstraint('switch_id', 'data_type', 'log_cre_date', name='switch_data_unique_constraint')
+    )

--- a/src/switch_service/models/switch_data_model.py
+++ b/src/switch_service/models/switch_data_model.py
@@ -1,0 +1,38 @@
+from enum import Enum
+from datetime import datetime
+
+class SwitchDataType(Enum):
+    RELAY_STATUS = "RELAY_STATUS"
+    TEMPERATURE = "TEMPERATURE"
+
+
+class SwitchDataModel:
+    """
+    SwitchDataModel class is a model class for the switch data object.
+    """
+
+    id: int
+    switch_id: int
+    data_type: SwitchDataType
+    log_cre_date: datetime
+    value_text: str
+    value_number: float
+
+    def __init__(self, id: int = None, switch_id: int = None, data_type: SwitchDataType = None, log_cre_date: datetime = None, value_text: str = None,
+                 value_number: float = None):
+        """
+        Initializes the SwitchDataModel with the provided values.
+
+        Args:
+            id (int): The id of the switch data.
+            switch_id (int): The id of the switch.
+            data_type (DataType): The type of the data.
+            value_text (str): The text value of the data.
+            value_number (float): The number value of the data.
+        """
+        self.id = id
+        self.switch_id = switch_id
+        self.data_type = data_type
+        self.log_cre_date = log_cre_date
+        self.value_text = value_text
+        self.value_number = value_number

--- a/tests/repository_service/tables/test_registry.py
+++ b/tests/repository_service/tables/test_registry.py
@@ -8,13 +8,13 @@ class TestRegistry(TestCase):
     def test_should_initialize_all_tables(self):
         # Setup
         metadata = MetaData()
-        expected_table_names = ['weather', 'electricity_price', 'switch', 'user', 'place', 'location']
+        expected_table_names = ['weather', 'electricity_price', 'switch', 'user', 'place', 'location', 'switch_data']
 
         # Actions
         tables = initialize_tables(metadata)
 
         # Asserts
-        self.assertEqual(6, len(tables))
+        self.assertEqual(7, len(tables))
         for table_name in expected_table_names:
             self.assertIn(table_name, tables)
             self.assertEqual(table_name, tables[table_name].name)

--- a/tests/repository_service/tables/test_switch_data_table.py
+++ b/tests/repository_service/tables/test_switch_data_table.py
@@ -1,0 +1,27 @@
+from unittest import TestCase
+from src.repository_service.tables import switch_data_table
+from sqlalchemy import MetaData, Table
+
+
+class TestSwitchDataTable(TestCase):
+
+    def test_should_create_table_with_correct_columns_and_constraints(self):
+        # Setup
+        mock_metadata = MetaData()
+        expected_table_name = 'switch_data'
+
+        # Actions
+        created_table = switch_data_table.create_switch_data_table(mock_metadata)
+
+        # Assert
+        self.assertIsInstance(created_table, Table)
+        self.assertEqual(created_table.name, expected_table_name)
+        self.assertEqual(len(created_table.columns), 6)
+        self.assertEqual(len(created_table.constraints), 3)
+        self.assertIn('id', created_table.columns)
+        self.assertIn('switch_id', created_table.columns)
+        self.assertIn('data_type', created_table.columns)
+        self.assertIn('log_cre_date', created_table.columns)
+        self.assertIn('value_text', created_table.columns)
+        self.assertIn('value_number', created_table.columns)
+        self.assertTrue(created_table.columns['id'].primary_key)

--- a/tests/repository_service/test_switch_repository_service.py
+++ b/tests/repository_service/test_switch_repository_service.py
@@ -1,3 +1,4 @@
+import datetime
 import unittest
 from unittest.mock import MagicMock
 from sqlalchemy.orm import clear_mappers
@@ -6,6 +7,8 @@ from src.configuration.base_configuration import BaseConfiguration
 from src.repository_service.switch_repository_service import SwitchRepositoryService
 from src.switch_service.models.switch_model import SwitchModel
 from src.place_service.models.place_model import PlaceModel
+from src.switch_service.models.switch_data_model import SwitchDataType
+from src.switch_service.models.switch_data_model import SwitchDataModel
 
 
 class TestRepositoryService(unittest.TestCase):
@@ -131,3 +134,20 @@ class TestRepositoryService(unittest.TestCase):
         # Asserts
         with self.assertRaises(ValueError):
             self.switch_repository_service.get_switch("uuid_2")
+
+    def test_store_switch_operational_data(self):
+        # Setup
+        switch = SwitchModel(name="Switch 1", uuid='uuid_1', place_id='1', status_calculation_logic="status_calculation_logic")
+        switch_data = SwitchDataModel(switch_id=1, data_type=SwitchDataType.RELAY_STATUS, log_cre_date=datetime.datetime.now(), value_text="ON")
+        expected_value_text = switch_data.value_text
+
+        # Actions
+        self.switch_repository_service.store_switch_data(switch)
+        self.switch_repository_service.store_switch_operational_data(switch_data)
+        with self.switch_repository_service.session_maker() as session:
+            stored_data = session.query(SwitchDataModel).all()
+
+        # Asserts
+        self.assertEqual(len(stored_data), 1)
+        self.assertEqual(stored_data[0].value_text, expected_value_text)
+

--- a/tests/switch_service/test_switch_service.py
+++ b/tests/switch_service/test_switch_service.py
@@ -4,6 +4,8 @@ from unittest.mock import Mock, patch, mock_open
 from src.switch_service.switch_service import SwitchService
 from src.configuration.base_configuration import BaseConfiguration
 from src.switch_service.models.switch_model import SwitchModel
+from src.switch_service.models.switch_data_model import SwitchDataModel
+from src.switch_service.models.switch_data_model import SwitchDataType
 
 
 class TestSwitchService(unittest.TestCase):
@@ -28,52 +30,69 @@ class TestSwitchService(unittest.TestCase):
         self.assertIn('get_weather_data_after_date', scope)
         self.assertIn('get_electricity_price_data_after_date', scope)
 
-    def test_get_switch_status_calculation_logic_when_switch_exists(self):
+    def test_fetch_switch_data_when_switch_exists(self):
         # Setup
         mock_switch = Mock()
-        mock_switch.status_calculation_logic = 'mock_logic'
         self.mock_repository_service.get_switch_for_user.return_value = mock_switch
 
         # Actions
-        result = self.switch_service._get_switch_status_calculation_logic('test_switch', 1)
+        result = self.switch_service._fetch_switch('test_switch', 1)
 
         # Asserts
-        self.assertEqual(result, 'mock_logic')
+        self.assertEqual(result, mock_switch)
         self.mock_repository_service.get_switch_for_user.assert_called_once_with('test_switch', 1)
 
-    def test_get_switch_status_calculation_logic_when_switch_does_not_exist(self):
+    def test_fetch_switch_data_when_switch_does_not_exist(self):
         # Setup
         self.mock_repository_service.get_switch_for_user.return_value = None
 
         # Actions
-        result = self.switch_service._get_switch_status_calculation_logic('test_switch', 1)
+        result = self.switch_service._fetch_switch('test_switch', 1)
 
         # Asserts
         self.assertIsNone(result)
         self.mock_repository_service.get_switch_for_user.assert_called_once_with('test_switch', 1)
 
-    @patch.object(SwitchService, '_get_switch_status_calculation_logic',
-                  return_value="def get_switch_status(): return 'ON'")
-    def test_get_switch_status_success(self, mock_get_logic):
-        status = self.switch_service.get_switch_status('test_switch', 1)
-        self.assertEqual(status, 'ON')
+    @patch.object(SwitchService, '_fetch_switch')
+    def test_get_switch_status_success(self, mock_fetch_switch):
+        # Setup
+        mock_switch = Mock()
+        mock_switch.status_calculation_logic = "def get_switch_status(): return 'ON'"
+        mock_fetch_switch.return_value = mock_switch
 
-    @patch.object(SwitchService, '_get_switch_status_calculation_logic',
-                  return_value="def get_switch_status(): raise Exception('error')")
-    def test_get_switch_status_error(self, mock_get_logic):
+        # Actions
         status = self.switch_service.get_switch_status('test_switch', 1)
+
+        # Asserts
+        self.assertEqual(status, 'ON')
+        self.mock_repository_service.store_switch_operational_data.assert_called_once()
+
+    @patch.object(SwitchService, '_fetch_switch')
+    def test_get_switch_status_error(self, mock_fetch_switch):
+        # Setup
+        mock_switch = Mock()
+        mock_switch.status_calculation_logic = "def get_switch_status(): raise Exception('error')"
+        mock_fetch_switch.return_value = mock_switch
+
+        # Actions
+        status = self.switch_service.get_switch_status('test_switch', 1)
+
+        # Asserts
         self.assertEqual(status, SwitchModel.SWITCH_VALUE_IF_ERROR_OCCURRED)
         self.mock_logger.error.assert_called()
+        self.mock_repository_service.store_switch_operational_data.assert_called_once()
 
-    @patch.object(SwitchService, '_get_switch_status_calculation_logic', return_value=None)
+    @patch.object(SwitchService, '_fetch_switch', return_value=None)
     def test_get_switch_status_not_found(self, mock_get_logic):
         status = self.switch_service.get_switch_status('non_existent_switch', 1)
         self.assertEqual(status, SwitchModel.SWITCH_VALUE_IF_SWITCH_NOT_IMPLEMENTED)
         self.mock_logger.error.assert_called()
+        self.mock_repository_service.store_switch_operational_data.assert_not_called()
 
     def test_store_switch_data(self):
         # Setup
-        switch_data = SwitchModel(name='test_switch', uuid="uuid_1", place_id='1', status_calculation_logic='mock_logic')
+        switch_data = SwitchModel(name='test_switch', uuid="uuid_1", place_id='1',
+                                  status_calculation_logic='mock_logic')
 
         # Actions
         self.switch_service.store_switch_data(switch_data)
@@ -83,10 +102,21 @@ class TestSwitchService(unittest.TestCase):
 
     def test_update_switch_data(self):
         # Setup
-        switch_data = SwitchModel(name='test_switch', uuid="uuid_1", place_id='1', status_calculation_logic='mock_logic')
+        switch_data = SwitchModel(name='test_switch', uuid="uuid_1", place_id='1',
+                                  status_calculation_logic='mock_logic')
 
         # Actions
         self.switch_service.update_switch_data(switch_data, 1)
 
         # Asserts
         self.mock_repository_service.update_switch_data.assert_called_once_with(switch_data, 1)
+
+    def test_store_switch_operational_data(self):
+        # Setup
+        switch_data = SwitchDataModel(switch_id=1, data_type=SwitchDataType.RELAY_STATUS, value_text='ON')
+
+        # Actions
+        self.switch_service.store_switch_operational_data(switch_data)
+
+        # Asserts
+        self.mock_repository_service.store_switch_operational_data.assert_called_once_with(switch_data)


### PR DESCRIPTION
- Implemented a new feature to store switch operational data with type enum (RELAY_STATUS, TEMPERATURE).
- Added functionality to store switch status data in the database when the status gets queried from the API.
- Created a new table 'switch_data' with columns: id, switch_id, data_type, log_cre_date, value_text, value_number.
- Updated existing tests and implemented new tests to ensure proper functionality.
- In the future, this feature can be extended to store various types of switch data, such as temperature, ampers etc.
- Data retrieval functionality will be implemented as needed.

This feature enhances the system by allowing storage of detailed switch operational data.