### PR TITLE
refactor: Update Flask endpoints to use IDs in REST requests

### DIFF
--- a/src/place_service/place_service.py
+++ b/src/place_service/place_service.py
@@ -21,9 +21,9 @@ class PlaceService:
             place (PlaceModel): PlaceModel object containing the place data.
 
         Returns:
-            PlaceModel: PlaceModel object containing the place data.
+            place_id: Id of the stored place
         """
-        self.place_repository_service.store_place_data(place)
+        return self.place_repository_service.store_place_data(place)
 
     def get_place(self, place_id, user_id):
         """

--- a/src/repository_service/place_repository_service.py
+++ b/src/repository_service/place_repository_service.py
@@ -14,18 +14,22 @@ class PlaceRepositoryService(BaseRepositoryService):
         Args: place (PlaceModel): PlaceModel object to be stored in the database.
 
         Returns:
-            None, raises an IntegrityError if the place already exists in the database.
+            place_id: Id of the stored place
+            Raises an IntegrityError if the place already exists in the database.
         """
+        place_id = None
         try:
             with self.session_maker() as session:
                 session.add(place)
                 session.commit()
+                place_id = int(place.id)
         except IntegrityError as ie:
             self.logger.error(f"Place with name {place.name} already exists in the database. Error = {ie}")
             raise
         except Exception as e:
             self.logger.error(f"Error storing place data into database. Error = {e}")
             raise
+        return place_id
 
     def get_place(self, place_id, user_id):
         """

--- a/src/repository_service/switch_repository_service.py
+++ b/src/repository_service/switch_repository_service.py
@@ -17,26 +17,31 @@ class SwitchRepositoryService(BaseRepositoryService):
         Args: switch (SwitchModel): SwitchModel object to be stored in the database.
 
         Returns:
-            None, raises an IntegrityError if the switch already exists in the database.
+            switch_id: Id of the stored switch
+            raises an IntegrityError if the switch already exists in the database.
         """
+        switch_id = None
         try:
             with self.session_maker() as session:
                 session.add(switch)
                 session.commit()
+                switch_id = int(switch.id)
         except IntegrityError:
             self.logger.error(f"Switch with name {switch.name} already exists in the database.")
             raise
         except Exception as e:
             self.logger.error(f"Error storing switch data into database. Error = {e}")
             raise
+        return switch_id
 
-    def update_switch_data(self, switch, user_id):
+    def update_switch_data(self, switch, user_id, uuid):
         """
         Updates an existing switch object in the database.
 
         Args:
             switch (SwitchModel): SwitchModel object to be updated in the database.
-            user_id (str): The user id of the user who owns the switch.
+            user_id (int): The user id of the user who owns the switch.
+            uuid (str): The uuid of the switch to be updated.
 
         Returns:
             None, raises a ValueError if the switch does not exist in the database.
@@ -44,35 +49,36 @@ class SwitchRepositoryService(BaseRepositoryService):
         try:
             with self.session_maker() as session:
                 try:
-                    existing_switch = self.get_switch_for_user(switch.uuid, user_id)
+                    existing_switch = self.get_switch_for_user(uuid, user_id)
                 except ValueError as ve:
                     self.logger.error(f"ValueError in get_switch: {ve}")
                     raise ve
                 existing_switch.status_calculation_logic = switch.status_calculation_logic
                 existing_switch.name = switch.name
                 existing_switch.place_id = switch.place_id
+                existing_switch.uuid = switch.uuid
                 session.add(existing_switch)
                 session.commit()
         except Exception as e:
             self.logger.error(f"Error updating switch data into database. Error = {e}")
             raise e
 
-    def get_switch(self, uuid):
+    def get_switch(self, id):
         """
-        Retrieves a switch object from the database based on the switch name.
+        Retrieves a switch object from the database based on the switch id.
 
         Args:
-            uuid (str): The uuid of the switch to be retrieved.
+            id (str): The id of the switch to be retrieved.
 
         Returns:
             SwitchModel: SwitchModel object retrieved from the database. ValueError is raised if the switch does not exist.
         """
         with self.session_maker() as session:
-            existing_switch = session.query(SwitchModel).filter(SwitchModel.uuid == uuid).first()
+            existing_switch = session.query(SwitchModel).filter(SwitchModel.id == id).first()
             if existing_switch:
                 return existing_switch
             else:
-                raise ValueError(f"Switch with uuid {uuid} does not exist in the database.")
+                raise ValueError(f"Switch with uuid {id} does not exist in the database.")
 
     def get_switch_for_user(self, uuid, user_id):
         """

--- a/src/repository_service/user_repository_service.py
+++ b/src/repository_service/user_repository_service.py
@@ -15,22 +15,41 @@ class UserRepositoryService(BaseRepositoryService):
             None, raises an IntegrityError if the user already exists in the database.
         """
         try:
+            user_id = None
             with self.session_maker() as session:
                 session.add(user)
                 session.commit()
+                user_id = int(user.id)
         except IntegrityError:
             self.logger.error(f"User with name {user.user_name} already exists in the database.")
             raise
         except Exception as e:
             self.logger.error(f"Error storing user data into database. Error = {e}")
             raise
+        return user_id
 
-    def get_user(self, user_name):
+    def get_user(self, user_id):
         """
         Retrieves a user object from the database based on the user name.
 
         Args:
-            user_name (str): The name of the user to be retrieved.
+            user_id (int): The id of the user to be retrieved.
+
+        Returns:
+            UserModel: The user object retrieved from the database.
+        """
+        with self.session_maker() as session:
+            user = session.query(UserModel).filter_by(id=user_id).first()
+            if user is None:
+                raise ValueError(f"User with id {user_id} does not exist in the database.")
+            return user
+
+    def get_user_by_user_name(self, user_name):
+        """
+        Retrieves a user object from the database based on the user name.
+
+        Args:
+            user_name (string): The name of the user to be retrieved.
 
         Returns:
             UserModel: The user object retrieved from the database.
@@ -38,8 +57,9 @@ class UserRepositoryService(BaseRepositoryService):
         with self.session_maker() as session:
             user = session.query(UserModel).filter_by(user_name=user_name).first()
             if user is None:
-                raise ValueError(f"User with name {user_name} does not exist in the database.")
+                raise ValueError(f"User with user_name {user_name} does not exist in the database.")
             return user
+
 
     def update_user_data(self, user):
         """
@@ -53,35 +73,35 @@ class UserRepositoryService(BaseRepositoryService):
         """
         try:
             with self.session_maker() as session:
-                existing_user = self.get_user(user.user_name)
+                existing_user = self.get_user(user.id)
                 existing_user.user_email = user.user_email
                 existing_user.password = user.password
                 session.add(existing_user)
                 session.commit()
         except ValueError as ve:
-            self.logger.error(f"User with name {user.user_name} does not exist in the database. Error = {ve}")
+            self.logger.error(f"User with id {user.id} does not exist in the database. Error = {ve}")
             raise ve
         except Exception as e:
             self.logger.error(f"Error updating user data into database. Error = {e}")
             raise e
 
-    def delete_user(self, user_name):
+    def delete_user(self, user_id):
         """
         Deletes a user object from the database based on the user name.
 
         Args:
-            user_name (str): The name of the user to be deleted.
+            user_id (int): The id of the user to be deleted.
 
         Returns:
             None, raises a ValueError if the user does not exist in the database.
         """
         try:
             with self.session_maker() as session:
-                user = self.get_user(user_name)
+                user = self.get_user(user_id)
                 session.delete(user)
                 session.commit()
         except ValueError as ve:
-            self.logger.error(f"User with name {user_name} does not exist in the database. Error = {ve}")
+            self.logger.error(f"User with id {user_id} does not exist in the database. Error = {ve}")
             raise ve
         except Exception as e:
             self.logger.error(f"Error deleting user data from database. Error = {e}")

--- a/src/rest_api/resources/place.py
+++ b/src/rest_api/resources/place.py
@@ -6,20 +6,20 @@ from src.location_service.models.location_model import LocationModel
 from src.place_service.models.place_model import PlaceModel
 from flask.views import MethodView
 from flask_smorest import Blueprint, abort
-from src.rest_api.schemas import PlaceSchema, PlaceGetSchema, PlaceSwitchesSchema, PlaceGetAllSchema
+from src.rest_api.schemas import PlaceSchema, PlaceSwitchesSchema
 from sqlalchemy.exc import IntegrityError
 from flask_jwt_extended import jwt_required, get_jwt_identity
 
 blp = Blueprint("places", __name__, description="Operations with places")
 
-@blp.route("/place")
-class Place(MethodView):
+@blp.route("/place/<int:place_id>")
+class PlaceItem(MethodView):
     """
     Class to handle the place resource.
     """
 
     @inject.autoparams()
-    def __init__(self, place_service: PlaceService, location_service: LocationService):
+    def __init__(self, place_service: PlaceService):
         """
         Initializes the Place class with the provided PlaceService.
 
@@ -27,8 +27,100 @@ class Place(MethodView):
             place_service (PlaceService): Service class to interact
         """
         self.place_service = place_service
+        self.logger = logging.getLogger(__name__)
+
+    @blp.response(200, PlaceSwitchesSchema)
+    @jwt_required()
+    def get(self, place_id):
+        """
+        Retrieves the place data from the database.
+
+        Arguments:
+            place_id (int): Place id.
+
+        Returns:
+            dict: Dictionary containing the place data.
+            Error 404: If the place is not found.
+            Error 500: If an error occurred while getting place data.
+        """
+        user_id = get_jwt_identity()
+        try:
+            place = self.place_service.get_place_and_switches(place_id, user_id)
+        except ValueError:
+            self.logger.error(f"Error getting place data from the database for the place id {place_id}.")
+            abort(404, message=f"Place with the id {place_id} not found.")
+        except Exception as e:
+            self.logger.error(f"Error getting place data from the database for the place id {place_id}. Error = {e}")
+            abort(500, message="An error occurred while getting place data.")
+        return place
+
+    @jwt_required()
+    def delete(self, place_id):
+        """
+        Deletes the place data from the database.
+
+        Arguments:
+            place_id (int): Place id.
+
+        Returns:
+            dict: Dictionary containing the message.
+            Error 404: If the place is not found.
+            Error 500: If an error occurred while deleting place data.
+        """
+        user_id = get_jwt_identity()
+        try:
+            self.place_service.delete_place(place_id, user_id)
+            return {"message": f"Place with the id {place_id} has been deleted."}, 200
+        except ValueError:
+            self.logger.error(f"Error deleting place data from the database for the place id {place_id}.")
+            abort(404, message=f"Place with the id {place_id} not found.")
+        except Exception as e:
+            self.logger.error(f"Error deleting place data from the database for the place id {place_id}. Error = {e}")
+            abort(500, message="An error occurred while deleting place data.")
+
+
+
+
+
+@blp.route("/place")
+class PlaceList(MethodView):
+
+    @inject.autoparams()
+    def __init__(self, place_service: PlaceService, location_service: LocationService):
+        """
+        Initializes the Places class with the provided PlaceService.
+
+        Arguments:
+            place_service (PlaceService): Service class to interact
+        """
+        self.place_service = place_service
         self.location_service = location_service
         self.logger = logging.getLogger(__name__)
+
+    @blp.response(200, PlaceSwitchesSchema(many=True))
+    @jwt_required()
+    def get(self):
+        """
+        Retrieves all places and switches for a user.
+
+        Arguments:
+            user id from the jwt token.
+
+        Returns:
+            dict: Dictionary containing the places and switches data.
+            Error 404: If the place is not found.
+            Error 500: If an error occurred while getting places and switches data.
+        """
+        user_id = get_jwt_identity()
+        try:
+            places = self.place_service.get_all_places_and_switches_for_user(user_id)
+        except ValueError:
+            self.logger.error(f"There are no places for user with id {user_id} in the database.")
+            abort(404, message=f"There are no places for user with id {user_id} in the database.")
+        except Exception as e:
+            self.logger.error(f"Error getting places data from the database for the user id {user_id}. Error = {e}")
+            abort(500, message="An error occurred while getting places data.")
+        return places
 
     @blp.arguments(PlaceSchema)
     @blp.response(201, PlaceSchema)
@@ -45,133 +137,30 @@ class Place(MethodView):
             Error 400: If a place with the same name already exists.
             Error 500: If an error occurred while storing place data.
         """
-        if place_data["user_id"] != get_jwt_identity():
+        user_id = place_data["user_id"]
+        if user_id != get_jwt_identity():
             self.logger.error(
-                f"User {get_jwt_identity()} is not authorized to create a place for user {place_data['user_id']}")
+                f"User {get_jwt_identity()} is not authorized to create a place for user {user_id}")
             abort(401, message="You are not authorized to create a place for this user.")
 
         try:
             location = LocationModel(**place_data["location"])
             self.location_service.store_location_data(location)
+
             stored_location = self.location_service.get_location(place_data["location"]["latitude"],
                                                                  place_data["location"]["longitude"])
 
             place = PlaceModel(name=place_data["name"],
                                location_id=stored_location.id,
-                               user_id=place_data["user_id"],
+                               user_id=user_id,
                                description=place_data["description"]
                                )
-            self.place_service.store_place_data(place)
-            return place_data, 201
+            stored_place_id = self.place_service.store_place_data(place)
+            stored_place = self.place_service.get_place(stored_place_id, user_id)
+            return stored_place, 201
         except IntegrityError:
             self.logger.error(f"Error storing place data into database. A place with the same name already exists.")
             abort(400, message="A place with the same name already exists.")
         except Exception as e:
             self.logger.error(f"Error storing place data into database. Error - {e}")
             abort(500, message="An error occurred while storing place data.")
-
-    @blp.arguments(PlaceGetSchema)
-    @blp.response(200, PlaceSwitchesSchema)
-    @jwt_required()
-    def get(self, place_data):
-        """
-        Retrieves the place data from the database.
-
-        Arguments:
-            place_data (dict): Dictionary containing the place id and user id.
-
-        Returns:
-            dict: Dictionary containing the place data.
-            Error 404: If the place is not found.
-            Error 500: If an error occurred while getting place data.
-            Error 401: If the user is not authorized to get the place data.
-        """
-        place_id = place_data["place_id"]
-        user_id = place_data["user_id"]
-        if user_id != get_jwt_identity():
-            self.logger.error(f"User {get_jwt_identity()} is not authorized to get place {place_id}")
-            abort(401, message="You are not authorized to get this place.")
-        try:
-            place = self.place_service.get_place_and_switches(place_id, user_id)
-        except ValueError:
-            self.logger.error(f"Error getting place data from the database for the place id {place_id}.")
-            abort(404, message=f"Place with the id {place_id} not found.")
-        except Exception as e:
-            self.logger.error(f"Error getting place data from the database for the place id {place_id}. Error = {e}")
-            abort(500, message="An error occurred while getting place data.")
-        return place
-
-    @blp.arguments(PlaceGetSchema)
-    @jwt_required()
-    def delete(self, place_data):
-        """
-        Deletes the place data from the database.
-
-        Arguments:
-            place_data (dict): Dictionary containing the place id and user id.
-
-        Returns:
-            dict: Dictionary containing the message.
-            Error 404: If the place is not found.
-            Error 500: If an error occurred while deleting place data.
-            Error 401: If the user is not authorized to delete the place data.
-        """
-        place_id = place_data["place_id"]
-        user_id = place_data["user_id"]
-        if user_id != get_jwt_identity():
-            self.logger.error(f"User {get_jwt_identity()} is not authorized to delete place {place_id}")
-            abort(401, message="You are not authorized to delete this place.")
-        try:
-            self.place_service.delete_place(place_id, user_id)
-            return {"message": f"Place with the id {place_id} has been deleted."}, 200
-        except ValueError:
-            self.logger.error(f"Error deleting place data from the database for the place id {place_id}.")
-            abort(404, message=f"Place with the id {place_id} not found.")
-        except Exception as e:
-            self.logger.error(f"Error deleting place data from the database for the place id {place_id}. Error = {e}")
-            abort(500, message="An error occurred while deleting place data.")
-
-
-@blp.route("/places")
-class Places(MethodView):
-
-    @inject.autoparams()
-    def __init__(self, place_service: PlaceService):
-        """
-        Initializes the Places class with the provided PlaceService.
-
-        Arguments:
-            place_service (PlaceService): Service class to interact
-        """
-        self.place_service = place_service
-        self.logger = logging.getLogger(__name__)
-
-    @blp.arguments(PlaceGetAllSchema)
-    @blp.response(200, PlaceSwitchesSchema(many=True))
-    @jwt_required()
-    def get(self, user_data):
-        """
-        Retrieves all places and switches for a user.
-
-        Arguments:
-            user_data (dict): Dictionary containing the user id.
-
-        Returns:
-            dict: Dictionary containing the places and switches data.
-            Error 404: If the user is not found.
-            Error 500: If an error occurred while getting places and switches data.
-            Error 401: If the user is not authorized to get the places and switches data.
-        """
-        user_id = user_data["user_id"]
-        if user_id != get_jwt_identity():
-            self.logger.error(f"User {get_jwt_identity()} is not authorized to get places for user {user_id}")
-            abort(401, message="You are not authorized to get places for this user.")
-        try:
-            places = self.place_service.get_all_places_and_switches_for_user(user_id)
-        except ValueError:
-            self.logger.error(f"There are no places for user with id {user_id} in the database.")
-            abort(404, message=f"There are no places for user with id {user_id} in the database.")
-        except Exception as e:
-            self.logger.error(f"Error getting places data from the database for the user id {user_id}. Error = {e}")
-            abort(500, message="An error occurred while getting places data.")
-        return places

--- a/src/rest_api/resources/switch.py
+++ b/src/rest_api/resources/switch.py
@@ -2,7 +2,7 @@ import inject
 import logging
 from flask.views import MethodView
 from flask_smorest import Blueprint, abort
-from ..schemas import SwitchSchema, SwitchGetSchema
+from ..schemas import SwitchSchema
 from src.switch_service.switch_service import SwitchService
 from src.switch_service.models.switch_model import SwitchModel
 from sqlalchemy.exc import IntegrityError
@@ -12,8 +12,102 @@ from flask_jwt_extended import jwt_required, get_jwt_identity
 blp = Blueprint("switches", __name__, description="Operations with switches")
 
 
+@blp.route("/switch/<string:uuid>")
+class SwitchItem(MethodView):
+    """
+    Class to handle the switch resource
+    """
+
+    @inject.autoparams()
+    def __init__(self, switch_service: SwitchService):
+        """
+        Initializes the Switch class with the provided SwitchService.
+
+        Arguments:
+            switch_service (SwitchService): Service class to interact
+        """
+        self.switch_service = switch_service
+        self.logger = logging.getLogger(__name__)
+
+    @blp.response(200, SwitchSchema)
+    @jwt_required()
+    def get(self, uuid):
+        """
+        Retrieves the switch data from the database.
+
+        Arguments:
+            switch_data (dict): Dictionary containing the switch data.
+
+        Returns:
+            dict: Dictionary containing the switch data.
+            Error 404: If the switch is not found.
+            Error 500: If an error occurred while getting switch data.
+        """
+        user_id = get_jwt_identity()
+        try:
+            switch = self.switch_service.get_switch_data_for_user(uuid, user_id)
+        except ValueError as e:
+            self.logger.error(f"Error getting switch data from the database for the switch uuid {uuid}. Error = {e}")
+            abort(404, message=f"Switch with the uuid {uuid} not found.")
+        except Exception as e:
+            self.logger.error(f"Error getting switch data from the database for the switch uuid {uuid}. Error = {e}")
+            abort(500, message="An error occurred while getting switch data.")
+        return switch
+
+    @blp.arguments(SwitchSchema)
+    @blp.response(200, SwitchSchema)
+    @jwt_required()
+    def put(self, switch_data, uuid):
+        """
+        Updates the switch data in the database.
+
+        Arguments:
+            uuid (str): UUID of the switch to be updated.
+            switch_data (dict): Dictionary containing the switch data.
+
+        Returns:
+            dict: Dictionary containing the updated switch data.
+            Error 404: If the switch is not found.
+            Error 500: If an error occurred while updating switch data.
+        """
+        try:
+            switch = SwitchModel(**switch_data)
+            user_id = get_jwt_identity()
+            self.switch_service.update_switch_data(switch, user_id, uuid)
+        except ValueError as e:
+            self.logger.error(f"Error updating switch data in the database. Error = {e}")
+            abort(404, message="Switch not found.")
+        except Exception as e:
+            self.logger.error(f"Error updating switch data in the database. Error = {e}")
+            abort(500, message="An error occurred while updating switch data.")
+        return switch_data
+
+    @jwt_required()
+    def delete(self, uuid):
+        """
+        Deletes the switch data from the database.
+
+        Arguments:
+            switch_data (dict): Dictionary containing the switch data.
+
+        Returns:
+            dict: Dictionary containing the switch data.
+            Error 404: If the switch is not found.
+            Error 500: If an error occurred while deleting switch data.
+        """
+        user_id = get_jwt_identity()
+        try:
+            self.switch_service.delete_switch(uuid, user_id)
+        except ValueError as e:
+            self.logger.error(f"Error deleting switch data from the database for the switch uuid {uuid}. Error = {e}")
+            abort(404, message=f"Switch with the uuid {uuid} not found.")
+        except Exception as e:
+            self.logger.error(f"Error deleting switch data from the database for the switch uuid {uuid}. Error = {e}")
+            abort(500, message="An error occurred while deleting switch data.")
+        return {"message": "Switch deleted"}, 200
+
 @blp.route("/switch")
-class Switch(MethodView):
+class SwitchList(MethodView):
     """
     Class to handle the switch resource
     """
@@ -48,8 +142,9 @@ class Switch(MethodView):
         uuid = switch_data["uuid"]
         try:
             switch = SwitchModel(**switch_data)
-            self.switch_service.store_switch_data(switch)
-            return switch_data
+            stored_switch_id = self.switch_service.store_switch_data(switch)
+            stored_switch = self.switch_service.get_switch_data(stored_switch_id)
+            return stored_switch
         except IntegrityError:
             self.logger.error(f"Error storing switch data into database. A switch with the same uuid {uuid} "
                               f"already exists or place does not exist id {place_id}.")
@@ -58,84 +153,3 @@ class Switch(MethodView):
         except Exception as e:
             self.logger.error(f"Error storing switch data into database. Error - {e}")
             abort(500, message="An error occurred while storing switch data.")
-
-    @blp.arguments(SwitchSchema)
-    @blp.response(200, SwitchSchema)
-    @jwt_required()
-    def put(self, switch_data):
-        """
-        Updates the switch data in the database.
-
-        Arguments:
-            switch_data (dict): Dictionary containing the switch data.
-
-        Returns:
-            dict: Dictionary containing the updated switch data.
-            Error 404: If the switch is not found.
-            Error 500: If an error occurred while updating switch data.
-        """
-        try:
-            switch = SwitchModel(**switch_data)
-            user_id = get_jwt_identity()
-            self.switch_service.update_switch_data(switch, user_id)
-        except ValueError as e:
-            self.logger.error(f"Error updating switch data in the database. Error = {e}")
-            abort(404, message="Switch not found.")
-        except Exception as e:
-            self.logger.error(f"Error updating switch data in the database. Error = {e}")
-            abort(500, message="An error occurred while updating switch data.")
-        return switch_data
-
-    @blp.arguments(SwitchGetSchema)
-    @blp.response(200, SwitchSchema)
-    @jwt_required()
-    def get(self, switch_data):
-        """
-        Retrieves the switch data from the database.
-
-        Arguments:
-            switch_data (dict): Dictionary containing the switch data.
-
-        Returns:
-            dict: Dictionary containing the switch data.
-            Error 404: If the switch is not found.
-            Error 500: If an error occurred while getting switch data.
-        """
-        switch_uuid = switch_data["uuid"]
-        user_id = get_jwt_identity()
-        try:
-            switch = self.switch_service.get_switch_data_for_user(switch_uuid, user_id)
-        except ValueError as e:
-            self.logger.error(f"Error getting switch data from the database for the switch uuid {switch_uuid}. Error = {e}")
-            abort(404, message=f"Switch with the uuid {switch_uuid} not found.")
-        except Exception as e:
-            self.logger.error(f"Error getting switch data from the database for the switch uuid {switch_uuid}. Error = {e}")
-            abort(500, message="An error occurred while getting switch data.")
-        return switch
-
-    @blp.arguments(SwitchGetSchema)
-    @blp.response(200, SwitchSchema)
-    @jwt_required()
-    def delete(self, switch_data):
-        """
-        Deletes the switch data from the database.
-
-        Arguments:
-            switch_data (dict): Dictionary containing the switch data.
-
-        Returns:
-            dict: Dictionary containing the switch data.
-            Error 404: If the switch is not found.
-            Error 500: If an error occurred while deleting switch data.
-        """
-        switch_uuid = switch_data["uuid"]
-        user_id = get_jwt_identity()
-        try:
-            self.switch_service.delete_switch(switch_uuid, user_id)
-        except ValueError as e:
-            self.logger.error(f"Error deleting switch data from the database for the switch uuid {switch_uuid}. Error = {e}")
-            abort(404, message=f"Switch with the uuid {switch_uuid} not found.")
-        except Exception as e:
-            self.logger.error(f"Error deleting switch data from the database for the switch uuid {switch_uuid}. Error = {e}")
-            abort(500, message="An error occurred while deleting switch data.")
-        return switch_data

--- a/src/rest_api/resources/switch_status.py
+++ b/src/rest_api/resources/switch_status.py
@@ -11,7 +11,7 @@ from src.switch_service.models.switch_model import SwitchModel
 blp = Blueprint("switch status", __name__, description="Operations on switch status")
 
 
-@blp.route("/switch/status")
+@blp.route("/switch/status/<string:switch_uuid>")
 class SwitchStatus(MethodView):
     """
     SwitchStatus class for handling switch status retrieval requests.
@@ -26,9 +26,8 @@ class SwitchStatus(MethodView):
         self.logger = logging.getLogger(__name__)
 
     @jwt_required()
-    @blp.arguments(SwitchStatusRetrivalSchema)
     @blp.response(200, SwitchStatusRetrivalSchema)
-    def get(self, switch_data):
+    def get(self, switch_uuid):
         """
         Retrieves the status of a switch based on the provided switch data.
 
@@ -38,7 +37,6 @@ class SwitchStatus(MethodView):
         Returns:
             dict: Dictionary containing the name of the switch and its status.
         """
-        switch_uuid = switch_data["uuid"]
         user_id = get_jwt_identity()
         switch_status = self.switch_service.get_switch_status(switch_uuid, user_id)
 

--- a/src/rest_api/resources/user.py
+++ b/src/rest_api/resources/user.py
@@ -3,7 +3,7 @@ import logging
 from datetime import timedelta
 from flask.views import MethodView
 from flask_smorest import Blueprint, abort
-from ..schemas import UserSchema, UserLoginSchema, UserGetSchema
+from ..schemas import UserSchema, UserLoginSchema
 from flask_jwt_extended import create_access_token
 from src.user_service.models.user_model import UserModel
 from src.user_service.user_service import UserService
@@ -12,9 +12,114 @@ from flask_jwt_extended import jwt_required, get_jwt_identity
 
 blp = Blueprint("users", __name__, description="Operations with users")
 
+@blp.route("/user/<int:user_id>")
+class UserItem(MethodView):
+    """
+    Class to handle to create a new user.
+    """
+
+    @inject.autoparams()
+    def __init__(self, user_service: UserService):
+        """
+        Initializes the User class with the provided UserService.
+
+        Arguments:
+            user_service (UserService): Service class to interact
+        """
+        self.user_service = user_service
+        self.logger = logging.getLogger(__name__)
+
+
+    @blp.arguments(UserSchema)
+    @blp.response(200, UserSchema)
+    @jwt_required()
+    def put(self, user_data, user_id):
+        """
+        Updates the user data in the database.
+
+        Arguments:
+            user_id (int): The id of the user to be updated.
+            user_data (dict): Dictionary containing the user data.
+
+        Returns:
+            dict: Dictionary containing the updated user data.
+            Error 400: If a user with the same name already exists.
+            Error 500: If an error occurred while updating user data.
+        """
+        if user_id != get_jwt_identity():
+            self.logger.error(f"User {get_jwt_identity()} is not authorized to update user {user_id}")
+            abort(401, message="You are not authorized to update this user.")
+        try:
+            hashed_password = self.user_service.hash_password(user_data["password"])
+            user_data["password"] = hashed_password
+            user_data["id"] = user_id
+            user = UserModel(**user_data)
+            self.user_service.update_user_data(user)
+            return user_data
+        except IntegrityError:
+            self.logger.error(f"Error updating user data into database. A user with the same name already exists.")
+            abort(400, message="A user with the same name already exists.")
+        except Exception as e:
+            self.logger.error(f"Error updating user data into database. Error - {e}")
+            abort(500, message="An error occurred while updating user data.")
+
+    @jwt_required()
+    def delete(self, user_id):
+        """
+        Deletes a user object from the database based on the user id.
+
+        Arguments:
+            user_id (int): The id of the user to be deleted.
+
+        Returns:
+            Status code 200: If the user is deleted successfully.
+            Error 404: If the user is not found.
+            Error 500: If an error occurred while deleting user data.
+        """
+        if user_id != get_jwt_identity():
+            self.logger.error(f"User {get_jwt_identity()} is not authorized to delete user {user_id}")
+            abort(401, message="You are not authorized to delete this user.")
+        try:
+            self.user_service.delete_user(user_id)
+        except ValueError:
+            self.logger.error(f"Error deleting user data from database for the user id {user_id}.")
+            abort(404, message=f"User with the id {user_id} not found.")
+        except Exception as e:
+            self.logger.error(f"Error deleting user data from database. Error - {e}")
+            abort(500, message="An error occurred while deleting user data.")
+
+        return {"message": f"User with user id {user_id} deleted successfully!"}, 200
+
+    @blp.response(200, UserSchema)
+    @jwt_required()
+    def get(self, user_id):
+        """
+        Retrieves the user data from the database.
+
+        Arguments:
+            user_id (int): User id.
+
+        Returns:
+            dict: Dictionary containing the user data.
+            Error 404: If the user is not found.
+            Error 500: If an error occurred while getting user data.
+            Error 401: If the user is not authorized to get the user data.
+        """
+        if user_id != get_jwt_identity():
+            self.logger.error(f"User {get_jwt_identity()} is not authorized to get user {user_id}")
+            abort(401, message="You are not authorized to get this user.")
+        try:
+            user = self.user_service.get_user(user_id)
+        except ValueError:
+            self.logger.error(f"Error getting user data from the database for the user name {user_name}.")
+            abort(404, message=f"User with the id {user_id} not found.")
+        except Exception as e:
+            self.logger.error(f"Error getting user data from the database for the user id {user_id}. Error = {e}")
+            abort(500, message="An error occurred while getting user data.")
+        return user
 
 @blp.route("/user")
-class User(MethodView):
+class UserList(MethodView):
     """
     Class to handle to create a new user.
     """
@@ -48,114 +153,15 @@ class User(MethodView):
             hashed_password = self.user_service.hash_password(user_data["password"])
             user_data["password"] = hashed_password
             user = UserModel(**user_data)
-            self.user_service.store_user_data(user)
-            return user_data
+            stored_user_id = self.user_service.store_user_data(user)
+            stored_user = self.user_service.get_user(stored_user_id)
+            return stored_user
         except IntegrityError:
             self.logger.error(f"Error storing user data into database. A user with the same name already exists.")
             abort(400, message="A user with the same name already exists.")
         except Exception as e:
             self.logger.error(f"Error storing user data into database. Error - {e}")
             abort(500, message="An error occurred while storing user data.")
-
-    @blp.arguments(UserSchema)
-    @blp.response(200, UserSchema)
-    @jwt_required()
-    def put(self, user_data):
-        """
-        Updates the user data in the database.
-
-        Arguments:
-            user_data (dict): Dictionary containing the user data.
-
-        Returns:
-            dict: Dictionary containing the updated user data.
-            Error 400: If a user with the same name already exists.
-            Error 500: If an error occurred while updating user data.
-        """
-        try:
-            existing_user = self.user_service.get_user(user_data["user_name"])
-        except ValueError:
-            self.logger.error(f"User with name {user_data['user_name']} does not exist in the database.")
-            abort(404, message="User not found.")
-        if existing_user.id != get_jwt_identity():
-            self.logger.error(f"User {get_jwt_identity()} is not authorized to update user {existing_user.id}")
-            abort(401, message="You are not authorized to update this user.")
-
-        try:
-            hashed_password = self.user_service.hash_password(user_data["password"])
-            user_data["password"] = hashed_password
-            user = UserModel(**user_data)
-            self.user_service.update_user_data(user)
-            return user_data
-        except IntegrityError:
-            self.logger.error(f"Error updating user data into database. A user with the same name already exists.")
-            abort(400, message="A user with the same name already exists.")
-        except Exception as e:
-            self.logger.error(f"Error updating user data into database. Error - {e}")
-            abort(500, message="An error occurred while updating user data.")
-
-    @blp.arguments(UserGetSchema)
-    @jwt_required()
-    def delete(self, user_data):
-        """
-        Deletes a user object from the database based on the user name.
-
-        Arguments:
-            user_data (dict): Dictionary containing the user data.
-
-        Returns:
-            Status code 200: If the user is deleted successfully.
-            Error 404: If the user is not found.
-            Error 500: If an error occurred while deleting user data.
-        """
-        user_name = user_data["user_name"]
-        try:
-            existing_user = self.user_service.get_user(user_name)
-        except ValueError:
-            self.logger.error(f"User with name {user_name} does not exist in the database.")
-            abort(404, message="User not found.")
-
-        if existing_user.id != get_jwt_identity():
-            self.logger.error(f"User {get_jwt_identity()} is not authorized to delete user {existing_user.id}")
-            abort(401, message="You are not authorized to delete this user.")
-
-        try:
-            self.user_service.delete_user(user_name)
-        except Exception as e:
-            self.logger.error(f"Error deleting user data from database. Error - {e}")
-            abort(500, message="An error occurred while deleting user data.")
-
-        return {"message": f"User with user name {user_name} deleted successfully!"}, 200
-
-    @blp.arguments(UserGetSchema)
-    @blp.response(200, UserSchema)
-    @jwt_required()
-    def get(self, user_data):
-        """
-        Retrieves the user data from the database.
-
-        Arguments:
-            user_data (dict): Dictionary containing the user data.
-
-        Returns:
-            dict: Dictionary containing the user data.
-            Error 404: If the user is not found.
-            Error 500: If an error occurred while getting user data.
-            Error 401: If the user is not authorized to get the user data.
-        """
-        user_name = user_data["user_name"]
-        try:
-            user = self.user_service.get_user(user_name)
-        except ValueError:
-            self.logger.error(f"Error getting user data from the database for the user name {user_name}.")
-            abort(404, message=f"User with the name {user_name} not found.")
-        except Exception as e:
-            self.logger.error(f"Error getting user data from the database for the user name {user_name}. Error = {e}")
-            abort(500, message="An error occurred while getting user data.")
-        if user.id != get_jwt_identity():
-            self.logger.error(f"User {get_jwt_identity()} is not authorized to get user {user.id}")
-            abort(401, message="You are not authorized to get this user.")
-        return user
 
 
 @blp.route("/login")
@@ -185,7 +191,7 @@ class Login(MethodView):
             Error 401: If the credentials are invalid.
         """
         try:
-            user = self.user_service.get_user(user_data["user_name"])
+            user = self.user_service.get_user_by_user_name(user_data["user_name"])
         except ValueError:
             self.logger.error(f"User with name {user_data['user_name']} does not exist in the database.")
             abort(401, message="Invalid credentials")

--- a/src/rest_api/schemas.py
+++ b/src/rest_api/schemas.py
@@ -5,21 +5,20 @@ class SwitchStatusRetrivalSchema(Schema):
     uuid = fields.Str(required=True)
     status = fields.Str(dump_only=True)
 
+
 class SwitchStatusCalculationTestSchema(Schema):
     switch_calculation_logic = fields.Str(required=True)
     switch_status = fields.Str(dump_only=True)
     error_message = fields.Str(dump_only=True)
 
+
 class SwitchSchema(Schema):
+    id = fields.Int(dump_only=True)
     name = fields.Str(required=True)
     uuid = fields.Str(required=True)
     place_id = fields.Int(required=True)
     status = fields.Str(dump_only=True)
     status_calculation_logic = fields.Str(required=True)
-
-
-class SwitchGetSchema(Schema):
-    uuid = fields.Str(required=True)
 
 
 class UserSchema(Schema):
@@ -32,10 +31,6 @@ class UserSchema(Schema):
 class UserLoginSchema(Schema):
     user_name = fields.Str(required=True)
     password = fields.Str(required=True)
-
-
-class UserGetSchema(Schema):
-    user_name = fields.Str(required=True)
 
 
 class LocationSchema(Schema):
@@ -52,15 +47,5 @@ class PlaceSchema(Schema):
     location = fields.Nested(LocationSchema(), required=True)
 
 
-class PlaceGetSchema(Schema):
-    place_id = fields.Int(required=True)
-    user_id = fields.Int(required=True)
-
-
-class PlaceGetAllSchema(Schema):
-    user_id = fields.Int(required=True)
-
-
 class PlaceSwitchesSchema(PlaceSchema):
     switches = fields.List(fields.Nested(SwitchSchema()), dump_only=True)
-

--- a/src/switch_service/switch_service.py
+++ b/src/switch_service/switch_service.py
@@ -143,30 +143,34 @@ class SwitchService:
 
         Arguments:
             switch (SwitchModel): The switch data to store.
-        """
-        self.repository_service.store_switch_data(switch)
 
-    def update_switch_data(self, switch, user_id):
+        Return:
+            switch_id: Id of the stored switch
+        """
+        return self.repository_service.store_switch_data(switch)
+
+    def update_switch_data(self, switch, user_id, uuid):
         """
         Updates the switch data in the database.
 
         Arguments:
             switch (SwitchModel): The switch data to update.
-            user_id (str): The id of the user.
+            user_id (int): The id of the user.
+            uuid (str): The uuid of the switch.
         """
-        self.repository_service.update_switch_data(switch, user_id)
+        self.repository_service.update_switch_data(switch, user_id, uuid)
 
-    def get_switch_data(self, switch_uuid):
+    def get_switch_data(self, switch_id):
         """
         Retrieves the switch data from the database.
 
         Arguments:
-            switch_uuid (str): The uuid of the switch.
+            switch_id (str): The id of the switch.
 
         Returns:
             SwitchModel: The switch data.
         """
-        return self.repository_service.get_switch(switch_uuid)
+        return self.repository_service.get_switch(switch_id)
 
     def get_switch_data_for_user(self, switch_uuid, user_id):
         """

--- a/src/user_service/user_service.py
+++ b/src/user_service/user_service.py
@@ -21,9 +21,22 @@ class UserService:
         Return:
             None
         """
-        self.user_repository_service.store_user_data(user)
+        user_id = self.user_repository_service.store_user_data(user)
+        return user_id
 
-    def get_user(self, user_name):
+    def get_user(self, user_id):
+        """
+        Retrieves the user data from the database.
+
+        Arguments:
+            user_id (int): The id of the user to be retrieved.
+
+        Return:
+            user (UserModel): UserModel object containing the user data.
+        """
+        return self.user_repository_service.get_user(user_id)
+
+    def get_user_by_user_name(self, user_name):
         """
         Retrieves the user data from the database.
 
@@ -33,7 +46,7 @@ class UserService:
         Return:
             user (UserModel): UserModel object containing the user data.
         """
-        return self.user_repository_service.get_user(user_name)
+        return self.user_repository_service.get_user_by_user_name(user_name)
 
     def update_user_data(self, user):
         """
@@ -47,17 +60,17 @@ class UserService:
         """
         self.user_repository_service.update_user_data(user)
 
-    def delete_user(self, user_name):
+    def delete_user(self, user_id):
         """
         Deletes the user data from the database.
 
         Arguments:
-            user_name (str): The name of the user to be deleted.
+            user_id (int): The id of the user to be deleted.
 
         Return:
             None
         """
-        self.user_repository_service.delete_user(user_name)
+        self.user_repository_service.delete_user(user_id)
 
     def hash_password(cls, password):
         """

--- a/tests/repository_service/test_switch_repository_service.py
+++ b/tests/repository_service/test_switch_repository_service.py
@@ -77,40 +77,44 @@ class TestRepositoryService(unittest.TestCase):
 
     def test_update_switch_data(self):
         # Setup
-        switch = SwitchModel(name="Switch 1", uuid='uuid_1', place_id='1', status_calculation_logic="status_calculation_logic")
-        updated_switch = SwitchModel(name="Switch 1", uuid='uuid_1', place_id='1', status_calculation_logic="new_status_calculation_logic")
+        uuid = 'uuid_1'
+        switch = SwitchModel(name="Switch 1", uuid=uuid, place_id='1', status_calculation_logic="status_calculation_logic")
+        updated_switch = SwitchModel(name="Switch 1", uuid=uuid, place_id='1', status_calculation_logic="new_status_calculation_logic")
 
         # Actions
         self.switch_repository_service.store_switch_data(switch)
-        self.switch_repository_service.update_switch_data(updated_switch, 1)
-        changed_switch = self.switch_repository_service.get_switch("uuid_1")
+        self.switch_repository_service.update_switch_data(updated_switch, 1, uuid)
+        changed_switch = self.switch_repository_service.get_switch("1")
 
         # Asserts
         self.assertEqual(changed_switch.status_calculation_logic, "new_status_calculation_logic")
 
     def test_update_switch_data_if_not_allowed_for_user(self):
         # Setup
-        switch = SwitchModel(name="Switch 1", uuid='uuid_1', place_id='1', status_calculation_logic="status_calculation_logic")
-        updated_switch = SwitchModel(name="Switch 1", uuid='uuid_1', place_id='1', status_calculation_logic="new_status_calculation_logic")
+        uuid = 'uuid_1'
+        switch = SwitchModel(name="Switch 1", uuid=uuid, place_id='1', status_calculation_logic="status_calculation_logic")
+        updated_switch = SwitchModel(name="Switch 1", uuid=uuid, place_id='1', status_calculation_logic="new_status_calculation_logic")
 
         # Actions
         self.switch_repository_service.store_switch_data(switch)
 
         # Asserts
         with self.assertRaises(ValueError):
-            self.switch_repository_service.update_switch_data(updated_switch, 2)
+            self.switch_repository_service.update_switch_data(updated_switch, 2, uuid)
 
     def test_update_switch_data_if_not_exists(self):
         # Setup
-        switch = SwitchModel(name="Switch 1", uuid='uuid_1', place_id='1', status_calculation_logic="status_calculation_logic")
-        updated_switch = SwitchModel(name="Switch 2", uuid='uuid_2', place_id='1', status_calculation_logic="new_status_calculation_logic")
+        uuid = 'uuid_1'
+        uuid_2 = 'uuid_2'
+        switch = SwitchModel(name="Switch 1", uuid=uuid, place_id='1', status_calculation_logic="status_calculation_logic")
+        updated_switch = SwitchModel(name="Switch 2", uuid=uuid_2, place_id='1', status_calculation_logic="new_status_calculation_logic")
 
         # Actions
         self.switch_repository_service.store_switch_data(switch)
 
         # Asserts
         with self.assertRaises(ValueError):
-            self.switch_repository_service.update_switch_data(updated_switch, 1)
+            self.switch_repository_service.update_switch_data(updated_switch, 1, uuid_2)
 
     def test_get_switch(self):
         # Setup
@@ -119,7 +123,7 @@ class TestRepositoryService(unittest.TestCase):
 
         # Actions
         self.switch_repository_service.store_switch_data(switch)
-        result = self.switch_repository_service.get_switch("uuid_1")
+        result = self.switch_repository_service.get_switch("1")
 
         # Asserts
         self.assertEqual(result.name, expected_name)

--- a/tests/repository_service/test_user_repository_service.py
+++ b/tests/repository_service/test_user_repository_service.py
@@ -48,12 +48,12 @@ class TestUserRepositoryService(unittest.TestCase):
     def test_update_user_data(self):
         # Setup
         user = UserModel(user_name="User 1", user_email="test@test.lv", password="password")
-        updated_user = UserModel(user_name="User 1", user_email="test@testttt.lv", password="new_password")
+        updated_user = UserModel(user_name="User 1", id=1, user_email="test@testttt.lv", password="new_password")
 
         # Actions
         self.user_repository_service.store_user_data(user)
         self.user_repository_service.update_user_data(updated_user)
-        changed_user = self.user_repository_service.get_user("User 1")
+        changed_user = self.user_repository_service.get_user_by_user_name("User 1")
 
         # Asserts
         self.assertEqual(changed_user.user_email, "test@testttt.lv")
@@ -71,6 +71,29 @@ class TestUserRepositoryService(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.user_repository_service.update_user_data(updated_user)
 
+    def test_get_user_by_user_name(self):
+        # Setup
+        user = UserModel(user_name="User 1", user_email="test@test.lv", password="password")
+        expected_name = user.user_name
+
+        # Actions
+        self.user_repository_service.store_user_data(user)
+        result = self.user_repository_service.get_user_by_user_name("User 1")
+
+        # Asserts
+        self.assertEqual(result.user_name, expected_name)
+
+    def test_get_user_by_user_name_if_not_exists(self):
+        # Setup
+        user = UserModel(user_name="User 1", user_email="test@test.lv", password="password")
+
+        # Actions
+        self.user_repository_service.store_user_data(user)
+
+        # Asserts
+        with self.assertRaises(ValueError):
+            self.user_repository_service.get_user_by_user_name("User 2")
+
     def test_get_user(self):
         # Setup
         user = UserModel(user_name="User 1", user_email="test@test.lv", password="password")
@@ -78,7 +101,7 @@ class TestUserRepositoryService(unittest.TestCase):
 
         # Actions
         self.user_repository_service.store_user_data(user)
-        result = self.user_repository_service.get_user("User 1")
+        result = self.user_repository_service.get_user(1)
 
         # Asserts
         self.assertEqual(result.user_name, expected_name)
@@ -92,4 +115,4 @@ class TestUserRepositoryService(unittest.TestCase):
 
         # Asserts
         with self.assertRaises(ValueError):
-            self.user_repository_service.get_user("User 2")
+            self.user_repository_service.get_user(2)

--- a/tests/rest_api/resources/test_place.py
+++ b/tests/rest_api/resources/test_place.py
@@ -5,7 +5,7 @@ from flask_jwt_extended import create_access_token, JWTManager
 from flask_smorest import Api
 from src.place_service.place_service import PlaceService
 from src.location_service.location_service import LocationService
-from src.rest_api.resources.place import Place, Places, blp
+from src.rest_api.resources.place import PlaceItem, PlaceList, blp
 from src.place_service.models.place_model import PlaceModel
 import inject
 
@@ -37,7 +37,7 @@ class TestPlace(unittest.TestCase):
 
         inject.configure(configure_injector)
 
-        self.place_view = Place(place_service=self.mock_place_service, location_service=self.mock_location_service)
+        self.place_view = PlaceItem(place_service=self.mock_place_service)
 
         with self.app.app_context():
             self.access_token = create_access_token(identity=1)
@@ -66,17 +66,12 @@ class TestPlace(unittest.TestCase):
 
         # Asserts
         self.assertEqual(response.status_code, 201)
-        self.assertEqual(response.json, place_data)
         self.mock_location_service.store_location_data.assert_called_once()
         self.mock_location_service.get_location.assert_called_once()
         self.mock_place_service.store_place_data.assert_called_once()
 
     def test_get_place_success(self):
         # Setup
-        place_data = {
-            "user_id": 1,
-            "place_id": 1
-        }
         mock_place = PlaceModel(name="test_place", user_id=1, description="some description", location_id=1)
         self.mock_place_service.get_place_and_switches.return_value = mock_place
         headers = {
@@ -85,7 +80,7 @@ class TestPlace(unittest.TestCase):
         }
 
         # Actions
-        response = self.client.get("/place", json=place_data, headers=headers)
+        response = self.client.get("/place/1", headers=headers)
 
         # Asserts
         self.assertEqual(response.status_code, 200)
@@ -100,10 +95,6 @@ class TestPlace(unittest.TestCase):
 
     def test_delete_place_success(self):
         # Setup
-        place_data = {
-            "place_id": "1",
-            "user_id": 1
-        }
         headers = {
             'Authorization': f'Bearer {self.access_token}',
             'Content-Type': 'application/json'
@@ -111,7 +102,7 @@ class TestPlace(unittest.TestCase):
         self.mock_place_service.delete_place.return_value = None
 
         # Actions
-        response = self.client.delete("/place", json=place_data, headers=headers)
+        response = self.client.delete("/place/1", headers=headers)
 
         # Asserts
         self.assertEqual(response.status_code, 200)

--- a/tests/rest_api/resources/test_switch.py
+++ b/tests/rest_api/resources/test_switch.py
@@ -4,7 +4,7 @@ from flask import Flask
 from flask_jwt_extended import create_access_token, JWTManager
 from flask_smorest import Api
 from src.switch_service.switch_service import SwitchService
-from src.rest_api.resources.switch import Switch, blp
+from src.rest_api.resources.switch import SwitchItem, blp
 from src.switch_service.models.switch_model import SwitchModel
 import inject
 
@@ -33,7 +33,7 @@ class TestSwitch(unittest.TestCase):
 
         inject.configure(configure_injector)
 
-        self.switch_view = Switch(switch_service=self.mock_switch_service)
+        self.switch_view = SwitchItem(switch_service=self.mock_switch_service)
 
         with self.app.app_context():
             self.access_token = create_access_token(identity='test_user')
@@ -62,7 +62,6 @@ class TestSwitch(unittest.TestCase):
 
         # Asserts
         self.assertEqual(response.status_code, 201)
-        self.assertEqual(response.json, switch_data)
 
     @patch('src.rest_api.resources.switch.jwt_required')
     def test_post_switch_failure(self, mock_jwt_required):
@@ -124,7 +123,7 @@ class TestSwitch(unittest.TestCase):
         }
 
         # Actions
-        response = self.client.put("/switch", json=switch_data, headers=headers)
+        response = self.client.put("/switch/1", json=switch_data, headers=headers)
 
         # Asserts
         self.assertEqual(response.status_code, 200)
@@ -147,7 +146,7 @@ class TestSwitch(unittest.TestCase):
         }
 
         # Actions
-        response = self.client.put("/switch", json=switch_data, headers=headers)
+        response = self.client.put("/switch/1", json=switch_data, headers=headers)
 
         # Asserts
         self.assertEqual(response.status_code, 404)
@@ -155,10 +154,7 @@ class TestSwitch(unittest.TestCase):
     @patch('src.rest_api.resources.switch.jwt_required')
     def test_get_switch_success(self, mock_jwt_required):
         # Setup
-        switch_data = {
-            "uuid": "uuid_1"
-        }
-        mock_switch = SwitchModel(name="test_switch", uuid="uuid_1", status_calculation_logic="some logic", place_id=1)
+        mock_switch = SwitchModel(id=1, name="test_switch", uuid="uuid_1", status_calculation_logic="some logic", place_id=1)
         self.mock_switch_service.get_switch_data_for_user.return_value = mock_switch
         mock_jwt_required.return_value = lambda fn: fn
         headers = {
@@ -167,11 +163,12 @@ class TestSwitch(unittest.TestCase):
         }
 
         # Actions
-        response = self.client.get("/switch", json=switch_data, headers=headers)
+        response = self.client.get("/switch/1", headers=headers)
 
         # Asserts
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json, {
+            "id": 1,
             "name": "test_switch",
             "uuid": "uuid_1",
             'status': None,
@@ -182,9 +179,6 @@ class TestSwitch(unittest.TestCase):
     @patch('src.rest_api.resources.switch.jwt_required')
     def test_get_switch_failure(self, mock_jwt_required):
         # Setup
-        switch_data = {
-            "uuid": "uuid_1"
-        }
         self.mock_switch_service.get_switch_data_for_user.side_effect = ValueError("Switch not found")
         mock_jwt_required.return_value = lambda fn: fn
         headers = {
@@ -193,7 +187,7 @@ class TestSwitch(unittest.TestCase):
         }
 
         # Actions
-        response = self.client.get("/switch", json=switch_data, headers=headers)
+        response = self.client.get("/switch/1", headers=headers)
 
         # Asserts
         self.assertEqual(response.status_code, 404)
@@ -201,9 +195,6 @@ class TestSwitch(unittest.TestCase):
     @patch('src.rest_api.resources.switch.jwt_required')
     def test_delete_switch_success(self, mock_jwt_required):
         # Setup
-        switch_data = {
-            "uuid": "uuid_1"
-        }
         mock_jwt_required.return_value = lambda fn: fn
         headers = {
             'Authorization': f'Bearer {self.access_token}',
@@ -212,18 +203,14 @@ class TestSwitch(unittest.TestCase):
         self.mock_switch_service.delete_switch.return_value = None
 
         # Actions
-        response = self.client.delete("/switch", json=switch_data, headers=headers)
+        response = self.client.delete("/switch/1", headers=headers)
 
         # Asserts
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json, switch_data)
 
     @patch('src.rest_api.resources.switch.jwt_required')
     def test_delete_switch_failure(self, mock_jwt_required):
         # Setup
-        switch_data = {
-            "uuid": "uuid_1"
-        }
         mock_jwt_required.return_value = lambda fn: fn
         headers = {
             'Authorization': f'Bearer {self.access_token}',
@@ -232,7 +219,7 @@ class TestSwitch(unittest.TestCase):
         self.mock_switch_service.delete_switch.side_effect = ValueError("Switch not found")
 
         # Actions
-        response = self.client.delete("/switch", json=switch_data, headers=headers)
+        response = self.client.delete("/switch/1", headers=headers)
 
         # Asserts
         self.assertEqual(response.status_code, 404)

--- a/tests/rest_api/resources/test_switch_status.py
+++ b/tests/rest_api/resources/test_switch_status.py
@@ -55,7 +55,7 @@ class TestSwitchStatus(unittest.TestCase):
 
         # Actions
         with self.app.app_context():
-            response = self.client.get("/switch/status", json={"uuid": "uuid_1"}, headers=headers)
+            response = self.client.get("/switch/status/uuid_1", headers=headers)
 
         # Asserts
         self.assertEqual(response.status_code, 200)
@@ -79,7 +79,7 @@ class TestSwitchStatus(unittest.TestCase):
 
         # Actions
         with self.app.app_context():
-            response = self.client.get("/switch/status", json={"uuid": "uuid_1"}, headers=headers)
+            response = self.client.get("/switch/status/uuid_1", headers=headers)
 
         # Asserts
         self.assertEqual(response.status_code, 500)

--- a/tests/switch_service/test_switch_service.py
+++ b/tests/switch_service/test_switch_service.py
@@ -129,10 +129,10 @@ class TestSwitchService(unittest.TestCase):
                                   status_calculation_logic='mock_logic')
 
         # Actions
-        self.switch_service.update_switch_data(switch_data, 1)
+        self.switch_service.update_switch_data(switch_data, 1, "uuid_1")
 
         # Asserts
-        self.mock_repository_service.update_switch_data.assert_called_once_with(switch_data, 1)
+        self.mock_repository_service.update_switch_data.assert_called_once_with(switch_data, 1, "uuid_1")
 
     def test_store_switch_operational_data(self):
         # Setup


### PR DESCRIPTION
- Refactored Flask endpoints to include IDs in the URI for REST requests instead of relying solely on the JSON body.
- Enhanced unit tests to cover new endpoint configurations with ID parameters.